### PR TITLE
implemented ros1 support for simulator: none

### DIFF
--- a/ros_workspace/src/turtle_odometry/launch/ros1_test.launch
+++ b/ros_workspace/src/turtle_odometry/launch/ros1_test.launch
@@ -7,6 +7,7 @@ includes the launch test file defined by the user
   <arg name="param_file" />
   <arg name="ros1_testpackage" />
   <arg name="ros1_testfile" />
+  <arg name="simulator" />
 
   <!-- provide parameters from artefact.yaml onto rosparam server -->
   <rosparam
@@ -15,11 +16,12 @@ includes the launch test file defined by the user
   />
 
   <!-- provide a simulator environment -->
-  <node
+  <node if="$(eval arg('simulator') == 'turtlesim')"
     name="turtlesim"
     pkg="turtlesim"
     type="turtlesim_node"
   />
+
 
   <!-- provide a data recorder -->
   <node


### PR DESCRIPTION
For tests where the simulator is already launched separately from Artefacts